### PR TITLE
feat(docs): 最新の変更を反映したドキュメントの更新

### DIFF
--- a/docs/admin_workflows.md
+++ b/docs/admin_workflows.md
@@ -1,5 +1,53 @@
 # 管理者ワークフロー
 
-- 大会作成 → ラウンド作成/締め/再開
-- 運営アカウント追加（admin）
-- 参加者アカウント作成（Service Role 経由）
+管理者がKatorinシステムで行う主要な操作と、関連するAPIエンドポイントの概要です。
+
+## 1. 大会の準備
+
+### 1.1. 管理者アカウントの作成
+必要に応じて、`POST /api/admin/users` を使用して新しい管理者アカウントを作成します。
+（この操作は通常、システム初期設定時に行われます）
+
+### 1.2. トーナメントの作成
+`POST /api/tournaments` を使用して、新しいトーナメントを作成します。
+```json
+{
+  "name": "新しい大会",
+  "slug": "new-tournament-2025"
+}
+```
+
+## 2. チームと参加者の管理
+
+### 2.1. チームの登録
+管理者は、作成したトーナメントに参加するチームを登録します。
+`POST /api/teams/register` を使用します。
+```json
+{
+  "name": "チームA",
+  "tournament_slug": "new-tournament-2025"
+}
+```
+このAPIは、チーム用のログイン情報（ユーザー名と自動生成されたパスワード）を返します。管理者はこの情報を各チームに伝達する必要があります。
+
+### 2.2. 参加者の管理
+管理者は、各チームの参加者を直接追加・編集・削除できます。
+- `GET /api/admin/teams/:teamId/participants`
+- `POST /api/admin/teams/:teamId/participants`
+- `PUT /api/admin/participants/:id`
+- `DELETE /api/admin/participants/:id`
+
+## 3. 大会の進行管理
+
+### 3.1. ラウンドの作成と管理
+`POST /api/tournaments/:tournamentId/rounds` を使用して、大会の最初のラウンドを作成します。
+大会が進行したら、`POST /api/tournaments/:tournamentId/rounds/:roundId/close` を使用して現在のラウンドを締め、次のラウンドを作成します。
+
+### 3.2. 試合結果の管理
+- **直接編集**: 管理者は `PUT /api/matches/:id` を使用して、いつでも試合結果を修正できます。
+- **入力許可**: `matches`テーブルの `input_allowed_team_id` を更新することで、特定のチームに結果の入力を許可できます。
+
+## 4. ユーザーアカウントのメンテナンス
+
+### パスワードリセット
+チームからパスワード忘れの連絡があった場合、管理者は `POST /api/admin/users/:userId/reset-password` を使用して、対象チームのパスワードをリセットできます。

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -4,62 +4,108 @@
 
 ## 認証について
 
-- ほとんどのエンドポイントで認証が必要です（`Authorization: Bearer <supabase_jwt>` ヘッダー）
-- 管理者専用エンドポイントは `app_metadata.role=admin` が必要
-- チーム専用エンドポイントはチームの認証トークンが必要
+- ほとんどのエンドポイントで認証が必要です (`Authorization: Bearer <supabase_jwt>` ヘッダー)。
+- 認証されたユーザー情報は `req.user` に格納されます。
+- **`requireAuth`**: JWTを検証し、認証済みでなければ `401` を返します。
+- **`requireAdmin`**: `app_metadata.role` が `admin` であることを要求します。
+- **`requireAdminOrEditor`**: 管理者、または `teams` テーブルの `has_admin_access` が `true` のチームユーザーを許可します。
+- **`attachTeam`**: 認証済みユーザー (`req.user`) に紐づくチーム情報を `teams` テーブルから取得し、`req.team` に格納します。
 
 ## 目次
 
-1. [基本エンドポイント](#基本エンドポイント)
+1. [認証 (Authentication)](#認証-authentication)
 2. [チーム管理 (Team Management)](#チーム管理-team-management)
 3. [参加者管理 (Participant Management)](#参加者管理-participant-management)
 4. [試合管理 (Match Management)](#試合管理-match-management)
 5. [トーナメント管理 (Tournament Management)](#トーナメント管理-tournament-management)
 6. [ラウンド管理 (Round Management)](#ラウンド管理-round-management)
-7. [管理者機能 (Admin Functions)](#管理者機能-admin-functions)
-8. [認証ユーティリティ (Auth Utilities)](#認証ユーティリティ-auth-utilities)
 
 ---
 
-## 基本エンドポイント
-
-### GET /api
-動作確認用のシンプルなエンドポイント。
-
-**認証**: 不要
-
-**レスポンス**:
-```
-Hello from Node.js backend!
-```
-
----
-
-## チーム管理 (Team Management)
+## 認証 (Authentication)
 
 ### GET /api/team/me
-現在認証されているユーザーに紐付くチーム情報を取得します。
+現在認証されているチームユーザーに紐付くチームの完全な情報を取得します。
 
-**認証**: 必須 (`requireAuth`)
+**認証**: 必須 (`requireAuth`, `attachTeam`)
 
 **レスポンス (200)**:
 ```json
 {
   "id": "uuid",
   "name": "チーム名",
-  "username": "team_username"
+  "username": "team_username",
+  "auth_user_id": "uuid",
+  "tournament_id": "uuid",
+  "has_admin_access": false,
+  "created_by": "uuid",
+  "created_at": "timestamp",
+  "updated_at": "timestamp"
 }
 ```
 
-**エラー**:
-- `404`: チームが見つかりません
+### POST /api/password-reset
+パスワードリセットメールを送信します。
+
+**認証**: 不要
+
+**リクエストボディ**:
+```json
+{
+  "email": "user@example.com"
+}
+```
+
+**レスポンス (200)**:
+```json
+{
+  "message": "パスワードリセットのリンクを生成しました。"
+}
+```
 
 ---
 
-### GET /api/teams
-すべてのチーム一覧を取得します。
+## チーム管理 (Team Management)
+
+### POST /api/teams/register
+新しいチームを登録し、関連するSupabase Authユーザーを作成します。
 
 **認証**: 必須 (`requireAuth`)
+
+**リクエストボディ**:
+```json
+{
+  "name": "チーム名",
+  "tournament_slug": "tournament-slug"
+}
+```
+
+**レスポンス (201)**:
+```json
+{
+  "id": "uuid",
+  "name": "チーム名",
+  "username": "team-name",
+  "created_at": "timestamp",
+  "tournament_id": "uuid",
+  "tournament_slug": "tournament-slug",
+  "generatedPassword": "randomly_generated_password"
+}
+```
+**注意**: `generatedPassword` はこのレスポンスでのみ返されます。クライアント側で安全に処理する必要があります。
+
+### POST /api/teams/login
+**[廃止]** このエンドポイントは廃止されました。
+クライアントはSupabase Authの `signInWithPassword` を直接使用してください。
+メールの形式は `{username}@{tournamentSlug}.players.local` です。
+
+### GET /api/teams
+指定されたトーナメントに属するチームの一覧を取得します。
+
+**認証**: 必須 (`requireAuth`)
+
+**クエリパラメータ**:
+- `tournament_slug` または `tournament_id` (どちらか必須)
 
 **レスポンス (200)**:
 ```json
@@ -68,105 +114,38 @@ Hello from Node.js backend!
     "id": "uuid",
     "name": "チーム名",
     "username": "team_username",
-    "created_at": "timestamp"
+    "created_at": "timestamp",
+    "tournament_id": "uuid",
+    "tournament_slug": "tournament-slug"
   }
 ]
 ```
-
----
 
 ### GET /api/teams/:id
 指定されたIDのチーム情報を取得します。
 
 **認証**: 必須 (`requireAuth`)
 
-**パラメータ**:
-- `id`: チームID (UUID)
-
 **レスポンス (200)**:
 ```json
 {
   "id": "uuid",
   "name": "チーム名",
   "username": "team_username",
-  "created_at": "timestamp"
+  "created_at": "timestamp",
+  "updated_at": "timestamp"
 }
 ```
-
-**エラー**:
-- `404`: チームが見つかりません
-
----
-
-### POST /api/teams/register
-新しいチームを登録します（Supabase Auth連携）。
-
-**認証**: 必須 (`requireAuth`)
-
-**リクエストボディ**:
-```json
-{
-  "name": "チーム名",
-  "username": "team_username"
-}
-```
-
-**レスポンス (201)**:
-```json
-{
-  "id": "uuid",
-  "name": "チーム名",
-  "username": "team_username",
-  "auth_user_id": "uuid"
-}
-```
-
-**エラー**:
-- `400`: バリデーションエラー
-- `500`: チーム作成失敗
-
----
-
-### POST /api/teams/login
-チームのログイン（旧実装、廃止予定の可能性あり）。
-
-**認証**: 不要
-
-**リクエストボディ**:
-```json
-{
-  "username": "team_username",
-  "password": "password"
-}
-```
-
-**レスポンス (200)**:
-```json
-{
-  "token": "jwt_token",
-  "team": {
-    "id": "uuid",
-    "name": "チーム名",
-    "username": "team_username"
-  }
-}
-```
-
----
 
 ### PUT /api/teams/:id
-チーム情報を更新します。
+チーム情報を更新します。チーム名を変更すると、関連するAuthユーザーのメールも更新されます。
 
 **認証**: 必須 (`requireAuth`)
-
-**パラメータ**:
-- `id`: チームID
 
 **リクエストボディ**:
 ```json
 {
-  "name": "新しいチーム名",
-  "username": "new_username"
+  "name": "新しいチーム名"
 }
 ```
 
@@ -175,39 +154,28 @@ Hello from Node.js backend!
 {
   "id": "uuid",
   "name": "新しいチーム名",
-  "username": "new_username"
+  "username": "new-team-name",
+  "created_at": "timestamp",
+  "updated_at": "timestamp"
 }
 ```
 
----
-
 ### DELETE /api/teams/:id
-チームを削除します。
+チームを削除します。関連するSupabase Authユーザーも同時に削除されます。
 
 **認証**: 必須 (`requireAuth`)
 
-**パラメータ**:
-- `id`: チームID
-
 **レスポンス (204)**: No Content
-
-**エラー**:
-- `404`: チームが見つかりません
-
----
 
 ### GET /api/teams/export
 チームデータをCSV形式でエクスポートします。
 
 **認証**: 必須 (`requireAuth`)
 
-**レスポンス (200)**:
-```csv
-id,name,username,created_at
-uuid,チーム名,team_username,2025-01-01T00:00:00Z
-```
+**クエリパラメータ**:
+- `tournament_slug` または `tournament_id` (どちらか必須)
 
----
+**レスポンス (200)**: CSVファイル
 
 ### POST /api/teams/import
 CSVファイルからチームデータをインポートします。
@@ -216,11 +184,20 @@ CSVファイルからチームデータをインポートします。
 
 **リクエスト**: `multipart/form-data`
 - `file`: CSVファイル
+- `tournament_slug`: トーナメントのスラッグ
 
 **レスポンス (200)**:
 ```json
 {
-  "imported": 10,
+  "message": "10件のチームをインポートしました。",
+  "imported": [
+    {
+      "id": "uuid",
+      "name": "インポートされたチーム",
+      "username": "imported-team",
+      "generatedPassword": "random_password"
+    }
+  ],
   "errors": []
 }
 ```
@@ -229,29 +206,31 @@ CSVファイルからチームデータをインポートします。
 
 ## 参加者管理 (Participant Management)
 
-### GET /api/team/participants
+### Team Self-Service Endpoints
+認証されたチームが自身の参加者を管理します。
+
+#### GET /api/team/participants
 認証されたチームの参加者一覧を取得します。
 
-**認証**: 必須 (`requireAuth`)
+**認証**: 必須 (`requireAuth`, `attachTeam`)
 
 **レスポンス (200)**:
 ```json
 [
   {
     "id": "uuid",
+    "team_id": "uuid",
     "name": "参加者名",
-    "can_edit": false,
-    "created_at": "timestamp"
+    "created_at": "timestamp",
+    "updated_at": "timestamp"
   }
 ]
 ```
 
----
-
-### POST /api/team/participants
+#### POST /api/team/participants
 認証されたチームに参加者を追加します。
 
-**認証**: 必須 (`requireAuth`)
+**認証**: 必須 (`requireAuth`, `attachTeam`)
 
 **リクエストボディ**:
 ```json
@@ -264,222 +243,55 @@ CSVファイルからチームデータをインポートします。
 ```json
 {
   "id": "uuid",
+  "team_id": "uuid",
   "name": "参加者名",
-  "can_edit": false,
-  "created_at": "timestamp"
+  "created_at": "timestamp",
+  "updated_at": "timestamp"
 }
 ```
 
----
-
-### PUT /api/team/participants/:participantId
+#### PUT /api/team/participants/:id
 参加者情報を更新します。
 
-**認証**: 必須 (`requireAuth`)
+**認証**: 必須 (`requireAuth`, `attachTeam`)
 
-**パラメータ**:
-- `participantId`: 参加者ID
+**レスポンス (200)**: 更新された参加者情報
 
-**リクエストボディ**:
-```json
-{
-  "name": "新しい参加者名"
-}
-```
-
-**レスポンス (200)**:
-```json
-{
-  "id": "uuid",
-  "name": "新しい参加者名",
-  "can_edit": false,
-  "created_at": "timestamp"
-}
-```
-
----
-
-### DELETE /api/team/participants/:participantId
+#### DELETE /api/team/participants/:id
 参加者を削除します。
 
-**認証**: 必須 (`requireAuth`)
-
-**パラメータ**:
-- `participantId`: 参加者ID
+**認証**: 必須 (`requireAuth`, `attachTeam`)
 
 **レスポンス (204)**: No Content
 
----
+### Admin Endpoints
+管理者が特定のチームの参加者を管理します。
 
-### GET /api/teams/:teamId/participants
-指定されたチームの参加者一覧を取得します（チーム認証版）。
-
-**認証**: 必須 (`requireTeamAuth`)
-
-**パラメータ**:
-- `teamId`: チームID
-
-**レスポンス (200)**:
-```json
-[
-  {
-    "id": "uuid",
-    "name": "参加者名",
-    "can_edit": true,
-    "created_at": "timestamp"
-  }
-]
-```
-
----
-
-### POST /api/teams/:teamId/participants
-指定されたチームに参加者を追加します（チーム認証版）。
-
-**認証**: 必須 (`requireTeamAuth`)
-
-**パラメータ**:
-- `teamId`: チームID
-
-**リクエストボディ**:
-```json
-{
-  "name": "参加者名"
-}
-```
-
-**レスポンス (201)**:
-```json
-{
-  "id": "uuid",
-  "name": "参加者名",
-  "can_edit": true,
-  "created_at": "timestamp"
-}
-```
-
----
-
-### PUT /api/participants/:id
-参加者情報を更新します（チーム認証版）。
-
-**認証**: 必須 (`requireTeamAuth`)
-
-**パラメータ**:
-- `id`: 参加者ID
-
-**リクエストボディ**:
-```json
-{
-  "name": "新しい参加者名"
-}
-```
-
-**レスポンス (200)**:
-```json
-{
-  "id": "uuid",
-  "name": "新しい参加者名"
-}
-```
-
----
-
-### DELETE /api/participants/:id
-参加者を削除します（チーム認証版）。
-
-**認証**: 必須 (`requireTeamAuth`)
-
-**パラメータ**:
-- `id`: 参加者ID
-
-**レスポンス (204)**: No Content
-
----
-
-### GET /api/admin/teams/:teamId/participants
+#### GET /api/admin/teams/:teamId/participants
 管理者が指定チームの参加者を取得します。
 
-**認証**: 必須 (`requireAuth`)
+**認証**: 必須 (`requireAuth`, `requireAdminOrEditor`)
 
-**パラメータ**:
-- `teamId`: チームID
+**レスポンス (200)**: 参加者の配列
 
-**レスポンス (200)**:
-```json
-[
-  {
-    "id": "uuid",
-    "name": "参加者名",
-    "can_edit": true,
-    "team_id": "uuid",
-    "created_at": "timestamp"
-  }
-]
-```
-
----
-
-### POST /api/admin/teams/:teamId/participants
+#### POST /api/admin/teams/:teamId/participants
 管理者が指定チームに参加者を追加します。
 
-**認証**: 必須 (`requireAuth`)
+**認証**: 必須 (`requireAuth`, `requireAdminOrEditor`)
 
-**パラメータ**:
-- `teamId`: チームID
+**レスポンス (201)**: 作成された参加者情報
 
-**リクエストボディ**:
-```json
-{
-  "name": "参加者名"
-}
-```
-
-**レスポンス (201)**:
-```json
-{
-  "id": "uuid",
-  "name": "参加者名",
-  "team_id": "uuid"
-}
-```
-
----
-
-### PUT /api/admin/participants/:id
+#### PUT /api/admin/participants/:id
 管理者が参加者情報を更新します。
 
-**認証**: 必須 (`requireAuth`)
+**認証**: 必須 (`requireAuth`, `requireAdminOrEditor`)
 
-**パラメータ**:
-- `id`: 参加者ID
+**レスポンス (200)**: 更新された参加者情報
 
-**リクエストボディ**:
-```json
-{
-  "name": "新しい参加者名",
-  "can_edit": true
-}
-```
-
-**レスポンス (200)**:
-```json
-{
-  "id": "uuid",
-  "name": "新しい参加者名",
-  "can_edit": true
-}
-```
-
----
-
-### DELETE /api/admin/participants/:id
+#### DELETE /api/admin/participants/:id
 管理者が参加者を削除します。
 
-**認証**: 必須 (`requireAuth`)
-
-**パラメータ**:
-- `id`: 参加者ID
+**認証**: 必須 (`requireAuth`, `requireAdminOrEditor`)
 
 **レスポンス (204)**: No Content
 
@@ -487,265 +299,114 @@ CSVファイルからチームデータをインポートします。
 
 ## 試合管理 (Match Management)
 
-### GET /api/matches
-試合一覧を取得します。
+### Admin Endpoints
+
+#### GET /api/matches
+トーナメントの全試合一覧を取得します。
 
 **認証**: 必須 (`requireAuth`)
 
 **クエリパラメータ**:
-- `tournamentId` (必須): トーナメントID
-- `roundId` (任意): ラウンドID
+- `tournamentId` (必須)
+- `roundId` (任意)
 
-**例**:
-```bash
-curl -H "Authorization: Bearer $TOKEN" \
-  "http://localhost:3001/api/matches?tournamentId=xxx&roundId=yyy"
-```
+**レスポンス (200)**: 試合情報の配列
 
-**レスポンス (200)**:
-```json
-[
-  {
-    "id": "uuid",
-    "team": "チーム名",
-    "player": "プレイヤー名",
-    "deck": "デッキ名",
-    "selfScore": 2,
-    "opponentScore": 1,
-    "opponentTeam": "対戦相手チーム",
-    "opponentPlayer": "対戦相手プレイヤー",
-    "opponentDeck": "対戦相手デッキ",
-    "date": "2025-01-01",
-    "tournament_id": "uuid",
-    "round_id": "uuid"
-  }
-]
-```
-
-**エラー**:
-- `401/403`: 認証/権限エラー
-
----
-
-### GET /api/matches/:id
-指定されたIDの試合情報を取得します。
+#### GET /api/matches/completed
+全トーナメントの完了済み試合一覧をページネーション付きで取得します。
 
 **認証**: 必須 (`requireAuth`)
 
-**パラメータ**:
-- `id`: 試合ID
+**クエリパラメータ**:
+- `page`, `pageSize`, `search`, `tournamentId`, `dateFrom`, `dateTo`
 
 **レスポンス (200)**:
 ```json
 {
-  "id": "uuid",
-  "team": "チーム名",
-  "player": "プレイヤー名",
-  "deck": "デッキ名",
-  "selfScore": 2,
-  "opponentScore": 1,
-  "date": "2025-01-01"
+  "data": [],
+  "total": 100,
+  "page": 1,
+  "pageSize": 25
 }
 ```
 
----
+#### GET /api/matches/:id
+IDで指定された試合情報を取得します。
 
-### POST /api/matches
+**認証**: 必須 (`requireAuth`)
+
+**レスポンス (200)**: 試合情報
+
+#### POST /api/matches
 新しい試合を作成します。
 
 **認証**: 必須 (`requireAuth`)
 
-**リクエストボディ**:
-```json
-{
-  "team": "チーム名",
-  "player": "プレイヤー名",
-  "deck": "デッキ名",
-  "selfScore": 2,
-  "opponentScore": 1,
-  "opponentTeam": "対戦相手チーム",
-  "opponentPlayer": "対戦相手プレイヤー",
-  "opponentDeck": "対戦相手デッキ",
-  "date": "2025-01-01",
-  "tournamentId": "uuid",
-  "roundId": "uuid"
-}
-```
+**レスポンス (201)**: 作成された試合情報
 
-**レスポンス (201)**:
-```json
-{
-  "id": "uuid",
-  "team": "チーム名",
-  ...
-}
-```
-
-**エラー**:
-- `400`: バリデーションエラー
-- `401/403`: 認証/権限エラー
-
----
-
-### PUT /api/matches/:id
+#### PUT /api/matches/:id
 試合情報を更新します。
 
 **認証**: 必須 (`requireAuth`)
 
-**パラメータ**:
-- `id`: 試合ID
+**レスポンス (200)**: 更新された試合情報
 
-**リクエストボディ**:
-```json
-{
-  "team": "新しいチーム名",
-  "selfScore": 3,
-  "opponentScore": 0
-}
-```
-
-**レスポンス (200)**:
-```json
-{
-  "id": "uuid",
-  "team": "新しいチーム名",
-  ...
-}
-```
-
-**エラー**:
-- `404`: 試合が見つかりません
-
----
-
-### DELETE /api/matches/:id
+#### DELETE /api/matches/:id
 試合を削除します。
 
 **認証**: 必須 (`requireAuth`)
 
-**パラメータ**:
-- `id`: 試合ID
-
 **レスポンス (204)**: No Content
 
-**エラー**:
-- `404`: 試合が見つかりません
+### Team Self-Service Endpoints
 
----
+#### GET /api/team/matches
+認証されたチームの試合一覧を取得します。
 
-### GET /api/team/matches
-チーム認証版：チームの試合一覧を取得します。
-
-**認証**: 必須 (`requireTeamAuth`)
+**認証**: 必須 (`requireAuth`, `attachTeam`)
 
 **クエリパラメータ**:
-- `tournamentId` (任意): トーナメントID
-- `roundId` (任意): ラウンドID
+- `status`: `open` (デフォルト), `finalized`, `all`
+- `limit`: 取得件数
 
-**レスポンス (200)**:
-```json
-[
-  {
-    "id": "uuid",
-    "team": "チーム名",
-    "player": "プレイヤー名",
-    ...
-  }
-]
-```
+**レスポンス (200)**: 試合情報の配列
 
----
+#### POST /api/team/matches
+認証されたチームの試合を作成します。
 
-### POST /api/team/matches
-チーム認証版：試合を作成します。
+**認証**: 必須 (`requireAuth`, `attachTeam`)
 
-**認証**: 必須 (`requireTeamAuth`)
+**レスポンス (201)**: 作成された試合情報
 
-**リクエストボディ**:
-```json
-{
-  "player": "プレイヤー名",
-  "deck": "デッキ名",
-  "selfScore": 2,
-  "opponentScore": 1,
-  "opponentTeam": "対戦相手チーム",
-  "opponentPlayer": "対戦相手プレイヤー",
-  "opponentDeck": "対戦相手デッキ",
-  "date": "2025-01-01"
-}
-```
+#### PUT /api/team/matches/:id
+認証されたチームが試合情報を更新します（確定前のみ）。
 
-**レスポンス (201)**:
-```json
-{
-  "id": "uuid",
-  ...
-}
-```
+**認証**: 必須 (`requireAuth`, `attachTeam`)
 
----
+**レスポンス (200)**: 更新された試合情報
 
-### PUT /api/team/matches/:id
-チーム認証版：試合情報を更新します。
+#### POST /api/team/matches/:id/result
+試合結果の入力、確定、またはロック解除を行います。
 
-**認証**: 必須 (`requireTeamAuth`)
-
-**パラメータ**:
-- `id`: 試合ID
+**認証**: 必須 (`requireAuth`, `attachTeam`)
 
 **リクエストボディ**:
 ```json
 {
-  "selfScore": 3,
-  "opponentScore": 0
+  "action": "save" | "finalize" | "cancel",
+  "payload": { ...試合情報のフィールド... }
 }
 ```
+- **`save`**: ドラフトとして保存し、編集ロックをかけます。
+- **`finalize`**: 結果を最終確定します。
+- **`cancel`**: 編集ロックを解除します。
 
-**レスポンス (200)**:
-```json
-{
-  "id": "uuid",
-  ...
-}
-```
+**レスポンス (200)**: 更新された試合情報
 
----
+#### DELETE /api/team/matches/:id
+認証されたチームが試合を削除します。
 
-### POST /api/team/matches/:id/result
-チーム認証版：試合結果を入力します。
-
-**認証**: 必須 (`requireTeamAuth`)
-
-**パラメータ**:
-- `id`: 試合ID
-
-**リクエストボディ**:
-```json
-{
-  "selfScore": 2,
-  "opponentScore": 1
-}
-```
-
-**レスポンス (200)**:
-```json
-{
-  "id": "uuid",
-  "selfScore": 2,
-  "opponentScore": 1,
-  "result_status": "finalized"
-}
-```
-
----
-
-### DELETE /api/team/matches/:id
-チーム認証版：試合を削除します。
-
-**認証**: 必須 (`requireTeamAuth`)
-
-**パラメータ**:
-- `id`: 試合ID
+**認証**: 必須 (`requireAuth`, `attachTeam`)
 
 **レスポンス (204)**: No Content
 
@@ -897,156 +558,3 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 **エラー**:
 - `400`: 後続ラウンドが存在する場合は再開不可
-
----
-
-## 管理者機能 (Admin Functions)
-
-### POST /api/admin/users
-管理者または参加者ユーザーを作成します（管理者のみ）。
-
-**認証**: 不要（ただし、サーバー側で `SUPABASE_SERVICE_ROLE_KEY` が必要）
-
-**リクエストボディ**:
-```json
-{
-  "email": "user@example.com",
-  "password": "password123",
-  "role": "admin"
-}
-```
-
-**レスポンス (201)**:
-```json
-{
-  "user": {
-    "id": "uuid",
-    "email": "user@example.com",
-    "app_metadata": {
-      "role": "admin"
-    }
-  }
-}
-```
-
-**エラー**:
-- `400`: バリデーションエラー
-- `500`: ユーザー作成失敗
-
----
-
-### POST /api/admin/users/:userId/reset-password
-管理者が指定ユーザーのパスワードをリセットします（管理者のみ）。
-
-**認証**: 必須 (`requireAuth` + `requireAdmin`)
-
-**パラメータ**:
-- `userId`: ユーザーID
-
-**リクエストボディ**:
-```json
-{
-  "newPassword": "new_password123"
-}
-```
-
-**レスポンス (200)**:
-```json
-{
-  "message": "パスワードがリセットされました"
-}
-```
-
----
-
-## 認証ユーティリティ (Auth Utilities)
-
-### POST /api/password-reset
-パスワードリセットメールを送信します。
-
-**認証**: 不要
-
-**リクエストボディ**:
-```json
-{
-  "email": "user@example.com"
-}
-```
-
-**レスポンス (200)**:
-```json
-{
-  "message": "パスワードリセットメールを送信しました"
-}
-```
-
-**注意**:
-- ローカル環境: Mailpit (http://127.0.0.1:54324) でメールを確認
-- 本番環境: Supabase設定のSMTPサーバーから送信
-
----
-
-## エラーフォーマット
-
-すべてのエラーレスポンスは以下の形式で返されます：
-
-```json
-{
-  "message": "エラーメッセージ",
-  "code": "ERROR_CODE",
-  "details": {}
-}
-```
-
-一般的なHTTPステータスコード：
-- `200`: 成功
-- `201`: 作成成功
-- `204`: 削除成功（レスポンスボディなし）
-- `400`: バリデーションエラー
-- `401`: 認証エラー
-- `403`: 権限エラー
-- `404`: リソースが見つかりません
-- `500`: サーバーエラー
-
----
-
-## 使用例
-
-### トーナメントと試合の作成フロー
-
-```bash
-# 1. ログイン（トークン取得は別途）
-TOKEN="your_jwt_token"
-
-# 2. トーナメント作成（管理者のみ）
-curl -X POST http://localhost:3001/api/tournaments \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "春季大会", "slug": "spring-2025"}'
-
-# 3. ラウンド作成（管理者のみ）
-curl -X POST http://localhost:3001/api/tournaments/{tournamentId}/rounds \
-  -H "Authorization: Bearer $TOKEN"
-
-# 4. 試合作成
-curl -X POST http://localhost:3001/api/matches \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "team": "チームA",
-    "player": "プレイヤー1",
-    "deck": "デッキX",
-    "selfScore": 2,
-    "opponentScore": 1,
-    "opponentTeam": "チームB",
-    "opponentPlayer": "プレイヤー2",
-    "opponentDeck": "デッキY",
-    "date": "2025-01-15",
-    "tournamentId": "{tournamentId}",
-    "roundId": "{roundId}"
-  }'
-
-# 5. 試合一覧取得
-curl -H "Authorization: Bearer $TOKEN" \
-  "http://localhost:3001/api/matches?tournamentId={tournamentId}&roundId={roundId}"
-```

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -1,18 +1,91 @@
-# Database Schema (Overview)
+# データベーススキーマ
 
-マイグレーションは `supabase/migrations/` に格納。主要テーブル:
+`supabase/migrations/`に保存されているマイグレーションによって定義されています。
 
-- tournaments: id, name, slug (unique), description, created_by, created_at
-- rounds: id, tournament_id, number, status('open'|'closed'), created_at
-- matches: id, tournament_id, round_id, team, player, deck,
-  selfScore, opponentScore, opponentTeam, opponentPlayer, opponentDeck, date,
-  input_allowed_team_id text, result_status text default 'draft',
-  locked_by text, locked_at timestamptz, finalized_at timestamptz
+## 主要テーブル
 
-代表的なインデックス（例）:
-- matches_result_status_idx(result_status)
-- matches_locked_by_idx(locked_by)
-- matches_input_allowed_idx(input_allowed_team_id)
+### `tournaments`
 
-将来対応:
-- ER 図を追補（DBML/SQL 生成から画像化）
+大会情報を管理します。
+
+| 列名 | 型 | 説明 |
+| :--- | :--- | :--- |
+| `id` | `uuid` | 主キー |
+| `name` | `text` | 大会名 |
+| `slug` | `text` | スラッグ (URL用、ユニーク) |
+| `description` | `text` | 大会の説明 |
+| `created_by` | `uuid` | 作成者のユーザーID (auth.users) |
+| `created_at` | `timestamptz` | 作成日時 |
+
+### `rounds`
+
+大会内の各ラウンドを管理します。
+
+| 列名 | 型 | 説明 |
+| :--- | :--- | :--- |
+| `id` | `uuid` | 主キー |
+| `tournament_id` | `uuid` | 関連する大会のID |
+| `number` | `integer` | ラウンド番号 |
+| `title` | `text` | ラウンドのタイトル |
+| `status` | `text` | 状態 ('open', 'closed'など) |
+| `created_at` | `timestamptz` | 作成日時 |
+| `closed_at` | `timestamptz` | 終了日時 |
+
+### `teams`
+
+大会に参加するチームを管理します。
+
+| 列名 | 型 | 説明 |
+| :--- | :--- | :--- |
+| `id` | `uuid` | 主キー |
+| `name` | `text` | チーム名 |
+| `username` | `text` | チームのログイン用ユーザー名 (ユニーク) |
+| `auth_user_id` | `uuid` | 関連する認証ユーザーID (auth.users) |
+| `has_admin_access` | `boolean` | 管理者権限を持つかどうか |
+| `tournament_id` | `uuid` | 関連する大会のID |
+| `created_by` | `uuid` | 作成者のユーザーID (auth.users) |
+| `created_at` | `timestamptz` | 作成日時 |
+| `updated_at` | `timestamptz` | 更新日時 |
+
+### `participants`
+
+チームに所属する参加者を管理します。
+
+| 列名 | 型 | 説明 |
+| :--- | :--- | :--- |
+| `id` | `uuid` | 主キー |
+| `team_id` | `uuid` | 所属するチームのID |
+| `name` | `text` | 参加者名 |
+| `created_by` | `uuid` | 作成者のユーザーID (auth.users) |
+| `created_at` | `timestamptz` | 作成日時 |
+| `updated_at` | `timestamptz` | 更新日時 |
+
+### `matches`
+
+対戦結果を記録します。
+
+| 列名 | 型 | 説明 |
+| :--- | :--- | :--- |
+| `id` | `uuid` | 主キー |
+| `tournament_id` | `uuid` | 関連する大会のID |
+| `round_id` | `uuid` | 関連するラウンドのID |
+| `team_id` | `uuid` | 関連するチームのID |
+| `team` | `text` | チーム名 |
+| `player` | `text` | プレイヤー名 |
+| `deck` | `text` | デッキ情報 |
+| `selfScore` | `text` | 自身のスコア |
+| `opponentScore` | `text` | 対戦相手のスコア |
+| `opponentTeam` | `text` | 対戦相手のチーム名 |
+| `opponentPlayer` | `text` | 対戦相手のプレイヤー名 |
+| `opponentDeck` | `text` | 対戦相手のデッキ情報 |
+| `date` | `date` | 対戦日 |
+| `input_allowed_team_id` | `text` | 結果入力を許可されたチームのID |
+| `result_status` | `text` | 結果の状態 ('draft', 'confirmed'など) |
+| `locked_by` | `text` | 結果をロックしたユーザー |
+| `locked_at` | `timestamptz` | ロック日時 |
+| `finalized_at` | `timestamptz` | 最終確定日時 |
+| `created_at` | `timestamptz` | 作成日時 |
+
+## 将来対応
+
+- ER図を追補（DBML/SQL生成から画像化）

--- a/docs/player_workflows.md
+++ b/docs/player_workflows.md
@@ -1,5 +1,38 @@
-# 参加者ワークフロー
+# プレイヤー（チーム）ワークフロー
 
-- ログイン（大会コード+ユーザー名→擬似メール）
-- 試合結果入力（許可時のみ）
-- 結果確認
+プレイヤー（チームアカウント）がKatorinシステムで行う主要な操作と、関連するAPIエンドポイントの概要です。
+
+## 1. ログイン
+
+管理者から提供された以下の情報を使用してログインします。
+- トーナメントのスラッグ (例: `spring-cup-2025`)
+- チームのユーザー名 (例: `team-phoenix`)
+- チームのパスワード
+
+クライアントアプリケーションは、これらの情報から `{username}@{tournamentSlug}.players.local` という形式のメールアドレスを内部的に生成し、Supabase Authの認証（`signInWithPassword`）を実行します。
+
+## 2. チームメンバーの管理
+
+ログイン後、チームは自身のチームに所属するプレイヤー（参加者）を管理できます。
+
+- **一覧取得**: `GET /api/team/participants`
+- **追加**: `POST /api/team/participants`
+- **更新**: `PUT /api/team/participants/:id`
+- **削除**: `DELETE /api/team/participants/:id`
+
+## 3. 試合結果の入力
+
+管理者が結果入力を許可した試合について、結果を入力・報告します。
+
+- **入力対象の試合取得**: `GET /api/team/matches` を使用して、入力が必要な（未確定の）試合一覧を取得します。
+- **結果の入力と確定**:
+  - `POST /api/team/matches/:id/result` を使用します。
+  - `action: 'save'` で下書き保存します。
+  - `action: 'finalize'` で結果を最終確定します。
+  - `action: 'cancel'` で編集中のロックを解除します。
+- **権限**: `matches` レコードの `input_allowed_team_id` が自チームのIDと一致する場合のみ、操作が許可されます。
+
+## 4. 試合結果の確認
+
+- **自チームの試合結果**: `GET /api/team/matches` に `status=finalized` または `status=all` クエリパラメータを付けて、過去の試合結果を確認します。
+- **大会全体の試合結果**: `GET /api/matches/completed` を使用して、トーナメントで完了したすべての試合結果を閲覧します。


### PR DESCRIPTION
最近のコードベースの変更に合わせて、以下のドキュメントを更新しました。\n\n- データベーススキーマのドキュメント () を、トーナメント、ラウンド、チーム、参加者、試合の最新のテーブル構造で更新しました。\n- RLSポリシーのドキュメント () を、各テーブルの現在のセキュリティポリシーを詳細に記述するように改訂しました。\n- APIエンドポイントのドキュメント () を、認証、チーム/参加者管理、新しい試合結果提出エンドポイントの変更を含む現在の実装に合わせて全面的に見直しました。\n- 管理者およびプレイヤーのワークフローに関するドキュメント (, ) を、最新のAPIおよびアプリケーションロジックに合わせるように更新しました。